### PR TITLE
changed incorrect naming for Marvel & Image

### DIFF
--- a/imprints.json
+++ b/imprints.json
@@ -1,5 +1,5 @@
 {
-   "version":"1.1",
+   "version":"1.2",
    "publishers":[
       {
          "DC Comics":[
@@ -148,7 +148,7 @@
          ]
       },
       {
-         "Marvel Comics":[
+         "Marvel":[
             {
                "name":"Amalgam Comics",
                "publication_run":"1996.01 - 1997.12"
@@ -347,7 +347,7 @@
          ]
       },
       {
-         "Image Comics":[
+         "Image":[
             {
                "name":"Avalon Studios",
                "publication_run":""


### PR DESCRIPTION
- changed ``Marvel Comics`` to ``Marvel`` ( follow existing naming on CV )
- changed ``Image Comics`` to ``Image`` ( follow existing naming on CV )
- bump version to v1.2